### PR TITLE
Changes to accomodate Atom 1.25, as tested on a mac OS High Sierra

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,4 +118,10 @@ html, html * {
 }
 ```
 
+In Atom v1.25+, the `::shadow` parameter is deprecated. Please use `.editor` instead to avoid annoying warnings:
+
+```
+atom-text-editor.editor {
+```
+
 That's it--pretty simple!

--- a/README.md
+++ b/README.md
@@ -44,20 +44,21 @@ Note `backgroundColor` is commented out.
 If you're running v1.25 or greater, `atom-window.coffee` may not exist. Instead, modify `src/main-process/atom-window.js`.
 Changing this:
 
-     ```javascript
-     const options = {
-       show: false,
-       title: 'Atom',
-     ```
+```javascript
+const options = {
+  show: false,
+  title: 'Atom',
+```
+
 to this:
 
-       ```javascript
-       const options = {
-         frame: false,
-         transparent: true,
-         show: false,
-         title: 'Atom',
-       ```
+```javascript
+const options = {
+  frame: false,
+  transparent: true,
+  show: false,
+  title: 'Atom',
+```
 
 Then run:
 

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ html, html * {
 
 In Atom v1.25+, the `::shadow` parameter is deprecated. Please use `.editor` instead to avoid annoying warnings:
 
-```
+```css
 atom-text-editor.editor {
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,24 @@ options =
 
 Note `backgroundColor` is commented out.
 
+If you're running v1.25 or greater, `atom-window.coffee` may not exist. Instead, modify `src/main-process/atom-window.js`.
+Changing this:
+
+     ```javascript
+     const options = {
+       show: false,
+       title: 'Atom',
+     ```
+to this:
+
+       ```javascript
+       const options = {
+         frame: false,
+         transparent: true,
+         show: false,
+         title: 'Atom',
+       ```
+
 Then run:
 
 ```sh

--- a/transparency.less
+++ b/transparency.less
@@ -10,7 +10,7 @@ atom-overlay > * {
   background: rgba(0, 0, 0, 0.9) !important;
 }
 
-atom-text-editor::shadow {
+atom-text-editor.editor {
   .cursor-line {
     background-color: rgba(0, 0, 0, 0.2) !important;
   }


### PR DESCRIPTION
- Advise users to modify `atom-window.js` instead of `atom-window.coffee`.
- Provide the required js/css syntax in both the `README.md` and `transparency.less` files.

Tested with mac OS High Sierra 10.13.1 with atom 1.25.0-dev-5a3e1d28c as cloned from their github.